### PR TITLE
Make getPlural example in annotate-js more useful by including example using {{$count}}

### DIFF
--- a/contents/dev-guide/annotate-js/index.md
+++ b/contents/dev-guide/annotate-js/index.md
@@ -41,7 +41,7 @@ Any string passed to `gettextCatalog.getString` is automatically marked for tran
 
 ```javascript
 angular.module("myApp").controller("helloController", function (gettextCatalog) {
-    var myString2 = gettextCatalog.getPlural(3, "Bird", "Birds");
+    var myString2 = gettextCatalog.getPlural(3, "One Bird", "{{$count}} Birds", {});
 });
 ```
 


### PR DESCRIPTION
Took me a while to realize I needed to pass in an empty scope for the interpolation to work, so this might help others.